### PR TITLE
VS-6549: Lock cost share checkbox in portal all the times

### DIFF
--- a/cpu-app/ClientApp/src/app/authenticated/subforms/program/program.component.html
+++ b/cpu-app/ClientApp/src/app/authenticated/subforms/program/program.component.html
@@ -90,7 +90,7 @@
 
       <div *ngIf="programApplication.hasPoliceContact" class="shared-cost-contact-div">
         <div class="form-check">
-          <input [disabled]="isDisabled" [(ngModel)]="programApplication.hasSharedCostContact" class="form-check-input" type="checkbox" id="hasSharedCostContactCheckbox" name="hasSharedCostContactCheckbox">
+          <input disabled [(ngModel)]="programApplication.hasSharedCostContact" class="form-check-input" type="checkbox" id="hasSharedCostContactCheckbox" name="hasSharedCostContactCheckbox">
           <label class="form-check-label form-label fw-normal" for="hasSharedCostContactCheckbox">
             Please select the check box to complete your cost share contact information with local Government:
           </label>


### PR DESCRIPTION
Lock the cost-share checkbox so service providers cannot change it