### PR TITLE
Enhance DataverseHealthCheck with logging and service readiness checks

### DIFF
--- a/cpu-app/HealthChecks/DataverseHealthCheck.cs
+++ b/cpu-app/HealthChecks/DataverseHealthCheck.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.Crm.Sdk.Messages;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
+using Microsoft.Extensions.Logging;
 using Microsoft.PowerPlatform.Dataverse.Client;
 
 namespace Gov.Cscp.Victims.Public.HealthChecks
@@ -10,10 +11,12 @@ namespace Gov.Cscp.Victims.Public.HealthChecks
     public class DataverseHealthCheck : IHealthCheck
     {
         private readonly IOrganizationServiceAsync _organizationService;
+        private readonly ILogger<DataverseHealthCheck> _logger;
 
-        public DataverseHealthCheck(IOrganizationServiceAsync organizationService)
+        public DataverseHealthCheck(IOrganizationServiceAsync organizationService, ILogger<DataverseHealthCheck> logger)
         {
             _organizationService = organizationService;
+            _logger = logger;
         }
 
         public async Task<HealthCheckResult> CheckHealthAsync(
@@ -23,13 +26,29 @@ namespace Gov.Cscp.Victims.Public.HealthChecks
         {
             try
             {
-                var response = (WhoAmIResponse)await _organizationService.ExecuteAsync(new WhoAmIRequest());
+                if (_organizationService is ServiceClient serviceClient && !serviceClient.IsReady)
+                {
+                    _logger.LogError(
+                        "DataverseHealthCheck status={CheckStatus} description={CheckDescription}",
+                        HealthStatus.Unhealthy,
+                        "Dataverse ServiceClient is not ready."
+                    );
+                    return HealthCheckResult.Unhealthy("Dataverse ServiceClient is not ready.");
+                }
 
-                return HealthCheckResult.Healthy($"Dataverse connection is healthy.");
+                await _organizationService.ExecuteAsync(new WhoAmIRequest());
+
+                return HealthCheckResult.Healthy("Dataverse connection is healthy.");
             }
             catch (Exception ex)
             {
-                return HealthCheckResult.Unhealthy("Dataverse connection failed.", ex);
+                _logger.LogError(
+                    ex,
+                    "DataverseHealthCheck status={CheckStatus} description={CheckDescription}",
+                    HealthStatus.Unhealthy,
+                    "Dataverse health check failed."
+                );
+                return HealthCheckResult.Unhealthy("Dataverse health check failed.", exception: ex);
             }
         }
     }

--- a/cpu-app/Program.cs
+++ b/cpu-app/Program.cs
@@ -246,20 +246,19 @@ namespace Gov.Cscp.Victims.Public
                 // Reduce log level for specific endpoints
                 options.GetLevel = (httpContext, elapsed, ex) =>
                 {
-                    if (ex != null) return Serilog.Events.LogEventLevel.Error;
+                    if (ex != null)
+                        return Serilog.Events.LogEventLevel.Error;
 
                     var path = httpContext.Request.Path.ToString();
 
-                    // health checks and lookup endpoints
-                    var logIgnoreEndpoints = new[] { "/hc", "/api/lookup" };
+                    if (path.StartsWith("/hc", StringComparison.OrdinalIgnoreCase))
+                        return httpContext.Response.StatusCode >= 500
+                            ? Serilog.Events.LogEventLevel.Error
+                            : Serilog.Events.LogEventLevel.Verbose;
 
-                    // Suppress logging for ignored endpoints
-                    if (Array.Exists(logIgnoreEndpoints, e => path.StartsWith(e, StringComparison.OrdinalIgnoreCase)))
-                    {
-                        return Serilog.Events.LogEventLevel.Verbose; // Below minimum level
-                    }
+                    if (path.StartsWith("/api/lookup", StringComparison.OrdinalIgnoreCase))
+                        return Serilog.Events.LogEventLevel.Verbose;
 
-                    // log warnings for requests that take longer than 1 second
                     return elapsed > 1000
                         ? Serilog.Events.LogEventLevel.Warning
                         : Serilog.Events.LogEventLevel.Information;


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

:information_source: [**Jira Ticket Number here**](Jira web address here)  

This pull request introduces improvements to health check logging and refines the logging level logic for HTTP endpoints. The main focus is on enhancing error visibility for Dataverse health checks and making logging behavior for health check and lookup endpoints more explicit and maintainable.

**Health check and logging improvements:**

* Enhanced the `DataverseHealthCheck` class to use an injected `ILogger<DataverseHealthCheck>`, providing detailed error logging when the Dataverse `ServiceClient` is not ready or when exceptions occur during health checks. [[1]](diffhunk://#diff-a628d596b3e179eee34cdd580c88947485d0d2e984f8757a20b8b7bb7eed7ccdR6-R19) [[2]](diffhunk://#diff-a628d596b3e179eee34cdd580c88947485d0d2e984f8757a20b8b7bb7eed7ccdL26-R51)

**Logging level logic updates:**

* Refined the HTTP request logging logic in `Program.cs` to:
  * Log errors for `/hc` (health check) endpoints only if the response status code is 500 or higher; otherwise, log at the verbose level.
  * Always log `/api/lookup` endpoint requests at the verbose level.
  * Remove the array-based endpoint ignore logic in favor of explicit path checks for better clarity and maintainability.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
