### PR TITLE
feat: implement outage alert component and logic for announcement banner

### DIFF
--- a/cpu-app/ClientApp/src/app/app.component.html
+++ b/cpu-app/ClientApp/src/app/app.component.html
@@ -1,15 +1,9 @@
 <app-header></app-header>
 <app-notification-banner></app-notification-banner>
+@if (configStore.showAnnouncementBanner()) {
+  <app-alert [message]="configStore.outageMessage()!"></app-alert>
+}
 <main class="container-fluid">
-  <div *ngIf="isOutage()" class="text-center warning">
-    <h1 class="warning">Site Outage</h1>
-    <h2 class="warning">
-      <b>{{ configuration.outageMessage }}</b>
-    </h2>
-    <h2 class="warning">
-      <b>{{ generateOutageDateMessage() }}</b>
-    </h2>
-  </div>
   <router-outlet></router-outlet>
 </main>
 <app-footer></app-footer>

--- a/cpu-app/ClientApp/src/app/app.component.ts
+++ b/cpu-app/ClientApp/src/app/app.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit, inject } from "@angular/core";
-import * as moment from "moment-timezone";
 import { ConfigurationStore } from "./core/store/configuration.store";
 
 @Component({
@@ -14,42 +13,5 @@ export class AppComponent implements OnInit {
 
   ngOnInit(): void {
     this.configStore.load();
-  }
-
-  isOutage() {
-    const configuration = this.configStore.configuration();
-    if (
-      !configuration ||
-      !configuration.outageEndDate ||
-      !configuration.outageStartDate ||
-      !configuration.outageMessage
-    ) {
-      return false;
-    }
-    const currentDate = moment().tz("America/Vancouver");
-    const outageStartDate = moment(configuration.outageStartDate).tz(
-      "America/Vancouver",
-    );
-    const outageEndDate = moment(configuration.outageEndDate).tz(
-      "America/Vancouver",
-    );
-    return currentDate.isBetween(outageStartDate, outageEndDate, null, "[]");
-  }
-
-  generateOutageDateMessage(): string {
-    const configuration = this.configStore.configuration();
-    if (!configuration) return "";
-    const startDate = moment(configuration.outageStartDate)
-      .tz("America/Vancouver")
-      .format("MMMM Do YYYY, h:mm a");
-    const endDate = moment(configuration.outageEndDate)
-      .tz("America/Vancouver")
-      .format("MMMM Do YYYY, h:mm a");
-    return (
-      "The system will be down for maintenance from " +
-      startDate +
-      " to " +
-      endDate
-    );
   }
 }

--- a/cpu-app/ClientApp/src/app/core/store/configuration.store.ts
+++ b/cpu-app/ClientApp/src/app/core/store/configuration.store.ts
@@ -7,6 +7,7 @@ import {
   withState,
 } from "@ngrx/signals";
 import { rxMethod } from "@ngrx/signals/rxjs-interop";
+import * as moment from "moment-timezone";
 import { catchError, of, pipe, switchMap, tap } from "rxjs";
 import { ConfigurationService } from "../api/services/configuration/configuration.service";
 import { Configuration } from "../models/configuration.interface";
@@ -31,6 +32,23 @@ export const ConfigurationStore = signalStore(
     featureHideReportSaveButton: computed(
       () => store.configuration()?.featureHideReportSaveButton ?? false,
     ),
+    outageMessage: computed(() => store.configuration()?.outageMessage ?? null),
+    outageStartDate: computed(
+      () => store.configuration()?.outageStartDate ?? null,
+    ),
+    outageEndDate: computed(() => store.configuration()?.outageEndDate ?? null),
+  })),
+  withComputed((store) => ({
+    showAnnouncementBanner: computed(() => {
+      const message = store.outageMessage();
+      const startDate = store.outageStartDate();
+      const endDate = store.outageEndDate();
+      if (!message || !startDate || !endDate) return false;
+      const current = moment().tz("America/Vancouver");
+      const start = moment(startDate).tz("America/Vancouver");
+      const end = moment(endDate).tz("America/Vancouver");
+      return current.isBetween(start, end, null, "[]");
+    }),
   })),
   withMethods((store) => {
     const configurationService = inject(ConfigurationService);

--- a/cpu-app/ClientApp/src/app/shared/alert/alert.component.html
+++ b/cpu-app/ClientApp/src/app/shared/alert/alert.component.html
@@ -1,0 +1,16 @@
+@if (isVisible) {
+  <div class="alert-banner" role="alert" aria-live="polite">
+    <div class="alert-banner__content">
+      <span class="alert-banner__icon" aria-hidden="true">&#9888;</span>
+      <div class="alert-banner__text">{{ message }}</div>
+    </div>
+    <button
+      class="alert-banner__dismiss"
+      type="button"
+      (click)="dismiss()"
+      aria-label="Dismiss announcement"
+      title="Dismiss">
+      &times;
+    </button>
+  </div>
+}

--- a/cpu-app/ClientApp/src/app/shared/alert/alert.component.scss
+++ b/cpu-app/ClientApp/src/app/shared/alert/alert.component.scss
@@ -1,0 +1,52 @@
+.alert-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  background-color: #f8bb47;
+  padding: 14px 30px;
+  margin: 16px 24px;
+  border-radius: 4px;
+  gap: 12px;
+
+  &__content {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex: 1;
+  }
+
+  &__icon {
+    font-size: 20px;
+    color: #2d2d2d;
+    flex-shrink: 0;
+    line-height: 1.4;
+  }
+
+  &__text {
+    color: #2d2d2d;
+    font-size: 15px;
+    line-height: 1.5;
+  }
+
+  &__dismiss {
+    background: none;
+    border: none;
+    font-size: 22px;
+    font-weight: bold;
+    color: #2d2d2d;
+    cursor: pointer;
+    padding: 0 4px;
+    line-height: 1;
+    flex-shrink: 0;
+    align-self: center;
+
+    &:hover {
+      color: #000;
+    }
+
+    &:focus {
+      outline: 2px solid #2d2d2d;
+      outline-offset: 2px;
+    }
+  }
+}

--- a/cpu-app/ClientApp/src/app/shared/alert/alert.component.ts
+++ b/cpu-app/ClientApp/src/app/shared/alert/alert.component.ts
@@ -1,0 +1,22 @@
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'app-alert',
+  templateUrl: './alert.component.html',
+  styleUrls: ['./alert.component.scss'],
+  standalone: false
+})
+export class AlertComponent {
+  @Input() message = '';
+  dismissed = false;
+
+  get isVisible(): boolean {
+    return !this.dismissed;
+  }
+
+  dismiss(): void {
+    this.dismissed = true;
+
+    // TODO: can be enhanced to pass event to parent component or service to handle dismissal state across the app if needed
+  }
+}

--- a/cpu-app/ClientApp/src/app/shared/shared.module.ts
+++ b/cpu-app/ClientApp/src/app/shared/shared.module.ts
@@ -2,15 +2,17 @@ import { CommonModule } from "@angular/common";
 import { NgModule } from "@angular/core";
 import { ReactiveFormsModule } from "@angular/forms";
 import { NgxMaskDirective } from "ngx-mask";
+import { AlertComponent } from "./alert/alert.component";
 import { FooterComponent } from "./footer/footer.component";
+import { FormFieldComponent } from "./form-field/form-field.component";
 import { HeaderComponent } from "./header/header.component";
 import { IconStepperComponent } from "./icon-stepper/icon-stepper.component";
 import { NotFoundComponent } from "./not-found/not-found.component";
 import { NotificationBannerComponent } from "./notification-banner/notification-banner.component";
-import { FormFieldComponent } from "./form-field/form-field.component";
 
 @NgModule({
   declarations: [
+    AlertComponent,
     FooterComponent,
     HeaderComponent,
     IconStepperComponent,
@@ -20,6 +22,7 @@ import { FormFieldComponent } from "./form-field/form-field.component";
   ],
   imports: [CommonModule, ReactiveFormsModule, NgxMaskDirective],
   exports: [
+    AlertComponent,
     FooterComponent,
     HeaderComponent,
     IconStepperComponent,


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue. Please also include relevant motivation and context. List any dependencies that are required for this change.

:information_source: [**Jira Ticket Number here**](Jira web address here)  

This pull request introduces a new, reusable outage announcement banner to the application, replacing the previous hardcoded outage logic with a more flexible and maintainable approach. The banner is now driven by configuration values and displayed only when appropriate, with improved styling and dismiss functionality. Outage logic has been moved to the `ConfigurationStore`, and the old logic has been removed from the main app component.

**Announcement Banner Implementation**

* Added a new `AlertComponent` (`alert.component.ts`, `alert.component.html`, `alert.component.scss`) to display an announcement banner with a dismiss button and improved accessibility and styling. [[1]](diffhunk://#diff-fb60e58e8128905da47b693e421ccb8eddacfafbd84b27161e5be5d4a959125bR1-R22) [[2]](diffhunk://#diff-149555cc8f6659216a45b005b50508a89d4c6365534e57fdb7c6cde8e80a00b4R1-R16) [[3]](diffhunk://#diff-c63cb4f443a1db47a8fa9ed47f0d94a95d0fa10c340e4a9f03f0909af87822f7R1-R52)
* Registered and exported `AlertComponent` in `SharedModule` for use across the app. [[1]](diffhunk://#diff-62de054eaf809db03f5a41aa13b43a42c397a159c07900c5edbca3520645c72dR5-R15) [[2]](diffhunk://#diff-62de054eaf809db03f5a41aa13b43a42c397a159c07900c5edbca3520645c72dR25)

**Configuration-Driven Outage Logic**

* Moved outage banner logic into `ConfigurationStore`, adding computed properties for `outageMessage`, `outageStartDate`, `outageEndDate`, and a new `showAnnouncementBanner` computed property that determines if the banner should be shown based on the current date and configuration.
* Added `moment-timezone` import to `configuration.store.ts` for date calculations.

**App Component Refactoring**

* Updated `app.component.html` to use the new announcement banner and remove the old outage display logic.
* Removed all outage-related methods and `moment-timezone` import from `app.component.ts`, delegating this responsibility to the store. [[1]](diffhunk://#diff-a8cec97e7d8d0ca7b358d1a16dc2fc7a10176aad12017f78380fc5fcf00035f7L2) [[2]](diffhunk://#diff-a8cec97e7d8d0ca7b358d1a16dc2fc7a10176aad12017f78380fc5fcf00035f7L18-L54)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
